### PR TITLE
Reproduce issue with pdf helper test case

### DIFF
--- a/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
+++ b/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
@@ -20,7 +20,7 @@ require File.expand_path('../../../../../../test_helper', __FILE__)
 class IssuesPdfHelperTest < ActiveSupport::TestCase
   
   fixtures :users, :projects, :roles, :members, :member_roles,
-          :enabled_modules, :enumerations
+          :enabled_modules, :issues, :enumerations
 
   include Redmine::Export::PDF::IssuesPdfHelper
 

--- a/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
+++ b/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
@@ -18,8 +18,9 @@
 require File.expand_path('../../../../../../test_helper', __FILE__)
 
 class IssuesPdfHelperTest < ActiveSupport::TestCase
+  
   #fixtures :users, :projects, :roles, :members, :member_roles,
-   #        :enabled_modules, :issues, :trackers, :enumerations
+  #        :enabled_modules, :issues, :trackers, :enumerations
 
   include Redmine::Export::PDF::IssuesPdfHelper
 

--- a/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
+++ b/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
@@ -19,8 +19,8 @@ require File.expand_path('../../../../../../test_helper', __FILE__)
 
 class IssuesPdfHelperTest < ActiveSupport::TestCase
   
-  #fixtures :users, :projects, :roles, :members, :member_roles,
-  #        :enabled_modules, :issues, :trackers, :enumerations
+  fixtures :users, :projects, :roles, :members, :member_roles,
+          :enabled_modules, :issues, :enumerations
 
   include Redmine::Export::PDF::IssuesPdfHelper
 

--- a/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
+++ b/test/unit/lib/redmine/export/pdf/issues_pdf_test.rb
@@ -20,7 +20,7 @@ require File.expand_path('../../../../../../test_helper', __FILE__)
 class IssuesPdfHelperTest < ActiveSupport::TestCase
   
   fixtures :users, :projects, :roles, :members, :member_roles,
-          :enabled_modules, :issues, :enumerations
+          :enabled_modules, :enumerations
 
   include Redmine::Export::PDF::IssuesPdfHelper
 


### PR DESCRIPTION
The IssuesPdfHelperTest test fails, when starting it in isolation. It's missing the neccessary fixture definitions. Depending on the random test order, this might also lead to errors, when running the whole test suite.